### PR TITLE
set read and write timeouts before driver configuration

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -49,6 +49,8 @@ bool Task::configureHook()
 {
     delete mDriver;
     mDriver = new dvl_teledyne::Driver;
+    mDriver->setReadTimeout(_io_read_timeout.get());
+    mDriver->setWriteTimeout(_io_write_timeout.get());
     if (!_io_port.get().empty())
     {
         mDriver->open(_io_port.get());


### PR DESCRIPTION
This is related to rock-drivers/drivers-dvl_teledyne#3.
The timeout properties have not been used during the configuration steps before.