### PR TITLE
API CHANGED. Adjusted to utilize the config struct added to dvl_teledyne

### DIFF
--- a/dvl_teledyne.orogen
+++ b/dvl_teledyne.orogen
@@ -3,6 +3,7 @@ version "0.1"
 
 using_library "dvl_teledyne"
 import_types_from "dvl_teledyne/PD0Messages.hpp"
+import_types_from "dvl_teledyne/Config.hpp"
 
 using_library "aggregator"
 import_types_from 'aggregator'
@@ -16,10 +17,10 @@ using_task_library "iodrivers_base"
 task_context "Task" do
     subclasses "iodrivers_base::Task"
 
+    property('config', 'dvl_teledyne/Config').
+        doc "configuration struct holding a complete set of settings for the dvl"
     property('config_file', '/std/string').
         doc "path to a text file containing DVL commands"
-    property('output_configuration', 'dvl_teledyne/OutputConfiguration').
-        doc "configuration of the output coordinate system"
 
     property('info', 'dvl_teledyne/DeviceInfo').
         doc "device information as read from the DVL (read-only)"

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -2,6 +2,7 @@
 
 #include "Task.hpp"
 #include <dvl_teledyne/Driver.hpp>
+#include <iodrivers_base/ConfigureGuard.hpp>
 #include <aggregator/TimestampEstimator.hpp>
 #include <base/Float.hpp>
 
@@ -9,7 +10,6 @@ using namespace dvl_teledyne;
 
 Task::Task(std::string const& name)
     : TaskBase(name)
-    , mDriver(0)
     , mTimestamper(0)
     , mLastSeq(-1)
 {
@@ -17,7 +17,6 @@ Task::Task(std::string const& name)
 
 Task::Task(std::string const& name, RTT::ExecutionEngine* engine)
     : TaskBase(name, engine)
-    , mDriver(0)
     , mTimestamper(0)
     , mLastSeq(-1)
 {
@@ -35,33 +34,39 @@ Task::~Task()
 
 bool Task::configureHook()
 {
-    delete mDriver;
-    mDriver = new dvl_teledyne::Driver;
-    mDriver->setReadTimeout(_io_read_timeout.get());
-    mDriver->setWriteTimeout(_io_write_timeout.get());
+    std::unique_ptr<dvl_teledyne::Driver> driver(new dvl_teledyne::Driver);
+
+    iodrivers_base::ConfigureGuard guard(this);
     if (!_io_port.get().empty())
+        driver->openURI(_io_port.get());
+    setDriver(driver.get());
+
+    if (! TaskBase::configureHook())
+        return false;
+
+    // Driver Configuration
+    if (driver->isValid())
     {
-        mDriver->open(_io_port.get());
-        mDriver->setConfigurationMode();
+        driver->setReadTimeout(_io_read_timeout.get());
+        driver->setWriteTimeout(_io_write_timeout.get());
+        driver->setConfigurationMode();
 
         // Send the configuration first, so that it gets overriden in the config
         // file (if people want to do it in the config file)
-        mDriver->applyConfig(_config.get());
+        driver->applyConfig(_config.get());
 
         // We can configure only if in direct access mode, i.e. send the file
         // only if _io_port is set
         if (!_config_file.get().empty())
-            mDriver->sendConfigurationFile(_config_file.get());
+            driver->sendConfigurationFile(_config_file.get());
     }
 
     delete mTimestamper;
     mTimestamper = new aggregator::TimestampEstimator(
             base::Time::fromSeconds(100),base::Time::fromSeconds(1));
 
-    setDriver(mDriver);
-
-    if (! TaskBase::configureHook())
-        return false;
+    mDriver = move(driver);
+    guard.commit();
     return true;
 }
 bool Task::startHook()
@@ -199,8 +204,9 @@ void Task::stopHook()
     TaskBase::stopHook();
 }
 
-// void Task::cleanupHook()
-// {
-//     TaskBase::cleanupHook();
-// }
+void Task::cleanupHook()
+{
+    TaskBase::cleanupHook();
+    mDriver.reset();
+}
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -13,12 +13,6 @@ Task::Task(std::string const& name)
     , mTimestamper(0)
     , mLastSeq(-1)
 {
-    OutputConfiguration default_config;
-    default_config.coordinate_system = INSTRUMENT;
-    default_config.use_attitude = true;
-    default_config.use_3beam_solution = true;
-    default_config.use_bin_mapping = false;
-    _output_configuration.set(default_config);
 }
 
 Task::Task(std::string const& name, RTT::ExecutionEngine* engine)
@@ -27,12 +21,6 @@ Task::Task(std::string const& name, RTT::ExecutionEngine* engine)
     , mTimestamper(0)
     , mLastSeq(-1)
 {
-    OutputConfiguration default_config;
-    default_config.coordinate_system = INSTRUMENT;
-    default_config.use_attitude = true;
-    default_config.use_3beam_solution = true;
-    default_config.use_bin_mapping = false;
-    _output_configuration.set(default_config);
 }
 
 Task::~Task()
@@ -58,7 +46,7 @@ bool Task::configureHook()
 
         // Send the configuration first, so that it gets overriden in the config
         // file (if people want to do it in the config file)
-        mDriver->setOutputConfiguration(_output_configuration.get());
+        mDriver->applyConfig(_config.get());
 
         // We can configure only if in direct access mode, i.e. send the file
         // only if _io_port is set

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -3,6 +3,7 @@
 #ifndef DVL_TELEDYNE_TASK_TASK_HPP
 #define DVL_TELEDYNE_TASK_TASK_HPP
 
+#include <memory>
 #include "dvl_teledyne/TaskBase.hpp"
 
 namespace aggregator {
@@ -16,7 +17,7 @@ namespace dvl_teledyne {
 	friend class TaskBase;
     protected:
 
-        Driver* mDriver;
+        std::unique_ptr<Driver> mDriver;
         aggregator::TimestampEstimator* mTimestamper;
 
         // The sequence number without wraparounds
@@ -92,7 +93,7 @@ namespace dvl_teledyne {
          * from Stopped to PreOperational, requiring the call to configureHook()
          * before calling start() again.
          */
-        // void cleanupHook();
+        void cleanupHook();
     };
 }
 


### PR DESCRIPTION
- Added the property "config" holding the new config struct.
- Removed the property "output_configuration" as these settings
  are now included in the new config.

It is still possible to set a config_file however. Settings set in
the given config file will overwrite any settings set in the config
as before.